### PR TITLE
Updated secret key input to be of type password

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                 </div>
 
                 <div class="control-group">
-                    <input autocorrect="off" spellcheck="false" type="text" class="login-field userInput stored" value="" placeholder="secret key" id="inputPhrase">
+                    <input autocorrect="off" spellcheck="false" type="password" class="login-field userInput stored" value="" placeholder="secret key" id="inputPhrase">
                     <label class="login-field-icon fui-lock" for="login-pass"></label>
                 </div>
 


### PR DESCRIPTION
It is important to hide our secret key form friends sneaking into our screens. It should be of `type="password"` as it's a "secret". This is much needed for Secure Passwords users.